### PR TITLE
Add feature that remembers your last team roster selection

### DIFF
--- a/src/content/features/remember-roster-selection.js
+++ b/src/content/features/remember-roster-selection.js
@@ -1,0 +1,39 @@
+import select from 'select-dom'
+
+import storage from '../../libs/storage'
+
+export default async parent => {
+  const { lastRosterSelection } = await storage.getAll()
+
+  const matchingRosterSelection = select
+    .all('.roster-selection__table tbody tr', parent)
+    .filter(el => lastRosterSelection.includes(getNickname(el)))
+
+  if (matchingRosterSelection.length) {
+    await storage.set({ lastRosterSelection: [] })
+    matchingRosterSelection.forEach(el => {
+      if (getMemberSelected(el)) return
+      select('.fi-checkbox', el).click()
+    })
+  }
+
+  select('form', parent).addEventListener('submit', onSubmit)
+}
+
+const onSubmit = async () => {
+  // HACK: We cannot access parent variable because this function would be
+  // recreated on every call of rememberRosterSelection and duplicate
+  // event listeners would be added
+  const parent = select('.modal-dialog')
+
+  const members = select
+    .all('.roster-selection__table tbody tr', parent)
+    .filter(el => getMemberSelected(el))
+    .map(el => getNickname(el))
+
+  await storage.set({ lastRosterSelection: members })
+}
+
+const getNickname = el => select('.roster-selection__table__name', el).innerText
+
+const getMemberSelected = el => select('input[type="checkbox"]', el).checked

--- a/src/content/features/remember-roster-selection.js
+++ b/src/content/features/remember-roster-selection.js
@@ -1,24 +1,7 @@
 import select from 'select-dom'
 
+import { getNickname, isMemberSelected } from '../libs/roster-selection'
 import storage from '../../libs/storage'
-
-export default async parent => {
-  const { lastRosterSelection } = await storage.getAll()
-
-  const matchingRosterSelection = select
-    .all('.roster-selection__table tbody tr', parent)
-    .filter(el => lastRosterSelection.includes(getNickname(el)))
-
-  if (matchingRosterSelection.length) {
-    await storage.set({ lastRosterSelection: [] })
-    matchingRosterSelection.forEach(el => {
-      if (getMemberSelected(el)) return
-      select('.fi-checkbox', el).click()
-    })
-  }
-
-  select('form', parent).addEventListener('submit', onSubmit)
-}
 
 const onSubmit = async () => {
   // HACK: We cannot access parent variable because this function would be
@@ -28,12 +11,26 @@ const onSubmit = async () => {
 
   const members = select
     .all('.roster-selection__table tbody tr', parent)
-    .filter(el => getMemberSelected(el))
+    .filter(el => isMemberSelected(el))
     .map(el => getNickname(el))
 
   await storage.set({ lastRosterSelection: members })
 }
 
-const getNickname = el => select('.roster-selection__table__name', el).innerText
+export default async parent => {
+  const { lastRosterSelection } = await storage.getAll()
 
-const getMemberSelected = el => select('input[type="checkbox"]', el).checked
+  const matchingRosterSelection = select
+    .all('.roster-selection__table tbody tr', parent)
+    .filter(el => lastRosterSelection.includes(getNickname(el)))
+
+  if (matchingRosterSelection.length > 0) {
+    await storage.set({ lastRosterSelection: [] })
+    matchingRosterSelection.forEach(el => {
+      if (isMemberSelected(el)) return
+      select('.fi-checkbox', el).click()
+    })
+  }
+
+  select('form', parent).addEventListener('submit', onSubmit)
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -34,6 +34,7 @@ import addSidebarHideButton from './features/add-sidebar-hide-button'
 import addPlayerProfileExtendedStats from './features/add-player-profile-extended-stats'
 import clickModalClose from './features/click-modal-close'
 import showSidebarHubQueuing from './features/show-sidebar-hub-queuing'
+import rememberRosterSelection from './features/remember-roster-selection'
 import isUserBanned from './bans/is-user-banned'
 import stopToxicity from './bans/stop-toxicity'
 import store from './store'
@@ -136,6 +137,8 @@ function observeBody() {
           modalElement
         )
         addPlayerProfileExtendedStats(modalElement)
+      } else if (modals.isSelectRoster(modalElement)) {
+        rememberRosterSelection(modalElement)
       }
     }
 

--- a/src/content/libs/modals.js
+++ b/src/content/libs/modals.js
@@ -29,3 +29,6 @@ export const isGlobalRankingUpdate = parent =>
 
 export const isPlayerProfileStats = () =>
   /players-modal\/.+\/stats\//.test(getCurrentPath())
+
+export const isSelectRoster = parent =>
+  select.exists('h3[translate-once="SELECT-ROSTER"]', parent)

--- a/src/content/libs/roster-selection.js
+++ b/src/content/libs/roster-selection.js
@@ -1,0 +1,7 @@
+import select from 'select-dom'
+
+export const getNickname = parent =>
+  select('.roster-selection__table__name', parent).innerText
+
+export const isMemberSelected = parent =>
+  select('input[type="checkbox"]', parent).checked

--- a/src/libs/settings.js
+++ b/src/libs/settings.js
@@ -25,6 +25,7 @@ export const DEFAULTS = {
   extensionEnabled: true,
   headerShowElo: true,
   hideFaceitClientHasLandedBanner: true,
+  lastRosterSelection: [],
   playerProfileLevelProgress: true,
   partyAutoAcceptInvite: false,
   matchQueueAutoReady: false,


### PR DESCRIPTION
This adds a feature that remembers your last team roster selection when queuing for 5v5s.

Currently it is frustrating that after a match or if someone did not accept the match, you have to select all the players from the roster again.