### PR TITLE
Add feature that sorts the team roster selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dom-chef": "^3.1.0",
     "element-ready": "^3.1.0",
     "ky": "^0.11.1",
+    "is-sorted": "^1.0.5",
     "lodash": "^4.17.10",
     "mem": "^3.0.0",
     "p-memoize": "^1.0.0",

--- a/src/content/features/sort-select-roster.js
+++ b/src/content/features/sort-select-roster.js
@@ -1,0 +1,26 @@
+import select from 'select-dom'
+import sorted from 'is-sorted'
+
+export default async parent => {
+  const tbody = select('.roster-selection__table tbody', parent)
+
+  const rows = select.all('tr', tbody)
+  if (sorted(rows, comparator)) return
+
+  rows.sort(comparator)
+  rows.forEach(el => {
+    tbody.appendChild(el)
+  })
+}
+
+const comparator = (a, b) => {
+  const aName = getNickname(a)
+  const bName = getNickname(b)
+
+  if (aName < bName) return -1
+  if (aName > bName) return 1
+  return 0
+}
+
+const getNickname = el =>
+  select('.roster-selection__table__name', el).innerText.toUpperCase()

--- a/src/content/features/sort-select-roster.js
+++ b/src/content/features/sort-select-roster.js
@@ -1,6 +1,17 @@
 import select from 'select-dom'
 import sorted from 'is-sorted'
 
+import { getNickname } from '../libs/roster-selection'
+
+const comparator = (a, b) => {
+  const aName = getNickname(a).toUpperCase()
+  const bName = getNickname(b).toUpperCase()
+
+  if (aName < bName) return -1
+  if (aName > bName) return 1
+  return 0
+}
+
 export default async parent => {
   const tbody = select('.roster-selection__table tbody', parent)
 
@@ -12,15 +23,3 @@ export default async parent => {
     tbody.appendChild(el)
   })
 }
-
-const comparator = (a, b) => {
-  const aName = getNickname(a)
-  const bName = getNickname(b)
-
-  if (aName < bName) return -1
-  if (aName > bName) return 1
-  return 0
-}
-
-const getNickname = el =>
-  select('.roster-selection__table__name', el).innerText.toUpperCase()

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -34,6 +34,7 @@ import addSidebarHideButton from './features/add-sidebar-hide-button'
 import addPlayerProfileExtendedStats from './features/add-player-profile-extended-stats'
 import clickModalClose from './features/click-modal-close'
 import showSidebarHubQueuing from './features/show-sidebar-hub-queuing'
+import sortSelectRoster from './features/sort-select-roster'
 import isUserBanned from './bans/is-user-banned'
 import stopToxicity from './bans/stop-toxicity'
 import store from './store'
@@ -136,6 +137,8 @@ function observeBody() {
           modalElement
         )
         addPlayerProfileExtendedStats(modalElement)
+      } else if (modals.isSelectRoster(modalElement)) {
+        sortSelectRoster(modalElement)
       }
     }
 

--- a/src/content/libs/modals.js
+++ b/src/content/libs/modals.js
@@ -29,3 +29,6 @@ export const isGlobalRankingUpdate = parent =>
 
 export const isPlayerProfileStats = () =>
   /players-modal\/.+\/stats\//.test(getCurrentPath())
+
+export const isSelectRoster = parent =>
+  select.exists('h3[translate-once="SELECT-ROSTER"]', parent)

--- a/src/content/libs/roster-selection.js
+++ b/src/content/libs/roster-selection.js
@@ -1,0 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+import select from 'select-dom'
+
+export const getNickname = parent =>
+  select('.roster-selection__table__name', parent).innerText

--- a/yarn.lock
+++ b/yarn.lock
@@ -5766,6 +5766,11 @@ is-scoped@^1.0.0:
   dependencies:
     scoped-regex "^1.0.0"
 
+is-sorted@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-sorted/-/is-sorted-1.0.5.tgz#ded2e357010bc79350b10ec2768e27db1b92b128"
+  integrity sha512-KZJvKDrI+Kg3ixeDaZQIt7RIwcGnm07+NSipyj1r9MtjDrLG678ETy4yO6dBJLUjejPdge9fLCGxsWkQO/3PJg==
+
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"


### PR DESCRIPTION
This adds a feature that sorts the team roster alphabetically by nickname when queuing for 5v5s.

Currently it is frustrating that when selecting players from the roster, you have to look for the players that you want from a list of (almost) random ordering.