### PR TITLE
Tournament helpers

### DIFF
--- a/src/content/features/add-tournament-checkin-player-elos.js
+++ b/src/content/features/add-tournament-checkin-player-elos.js
@@ -1,0 +1,54 @@
+/** @jsx h */
+import { h } from 'dom-chef'
+import select from 'select-dom'
+import { getPlayer } from '../libs/faceit'
+import { hasFeatureAttribute, setFeatureAttribute } from '../libs/dom-element'
+import { isModalOpen } from '../libs/utils'
+import createEloElement from '../components/elo'
+
+const FEATURE_ATTRIBUTE = 'tournament-checkin-player-elo'
+
+export default async parentElement => {
+  if (!isModalOpen()) {
+    return
+  }
+
+  const playerElements = select.all('.roster .roster__member', parentElement)
+
+  if (playerElements.length === 0) {
+    return
+  }
+
+  /* Need to find a way to get the assoicated tournament or id on checkin
+  const tournamentId = getTournamentId()
+  const tournament = await getTournament(tournamentId)
+  const { game } = tournament */
+
+  const game = 'csgo'
+
+  playerElements.forEach(async playerElement => {
+    if (hasFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)) {
+      return
+    }
+
+    setFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)
+
+    const nicknameElement = select(
+      'strong[ng-bind="::member.nickname"]',
+      playerElement
+    )
+    const nickname = nicknameElement.textContent
+
+    const player = await getPlayer(nickname)
+
+    if (!player) {
+      return
+    }
+
+    const elo = player.games[game].faceitElo || '–'
+
+    const eloElement = createEloElement({ elo, alignRight: true })
+
+    playerElement.append(<div className="text-muted text-md">{eloElement}</div>)
+  })
+}

--- a/src/content/features/add-tournament-checkin-player-flags.js
+++ b/src/content/features/add-tournament-checkin-player-flags.js
@@ -1,0 +1,49 @@
+/** @jsx h */
+import { h } from 'dom-chef'
+import select from 'select-dom'
+import { getPlayer } from '../libs/faceit'
+import { hasFeatureAttribute, setFeatureAttribute } from '../libs/dom-element'
+import { isModalOpen } from '../libs/utils'
+import createFlagElement from '../components/flag'
+
+const FEATURE_ATTRIBUTE = 'tournament-checkin-player-flags'
+
+export default async parentElement => {
+  if (!isModalOpen()) {
+    return
+  }
+
+  const playerElements = select.all('.roster .roster__member', parentElement)
+
+  if (playerElements.length === 0) {
+    return
+  }
+
+  playerElements.forEach(async playerElement => {
+    if (hasFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)) {
+      return
+    }
+
+    setFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)
+
+    const nicknameElement = select(
+      'strong[ng-bind="::member.nickname"]',
+      playerElement
+    )
+    const nickname = nicknameElement.textContent
+
+    const player = await getPlayer(nickname)
+
+    if (!player) {
+      return
+    }
+
+    const country = player.country || 0
+
+    const flagElement = createFlagElement({ country })
+
+    nicknameElement.prepend(
+      <span style={{ 'margin-right': '5px' }}>{flagElement}</span>
+    )
+  })
+}

--- a/src/content/features/add-tournament-checkin-player-levels.js
+++ b/src/content/features/add-tournament-checkin-player-levels.js
@@ -1,0 +1,56 @@
+/** @jsx h */
+import { h } from 'dom-chef'
+import select from 'select-dom'
+import {  getPlayer } from '../libs/faceit'
+import { hasFeatureAttribute, setFeatureAttribute } from '../libs/dom-element'
+import { isModalOpen } from '../libs/utils'
+import createSkillLevelElement from '../components/skill-level'
+
+const FEATURE_ATTRIBUTE = 'tournament-checkin-player-levels'
+
+export default async parentElement => {
+  if (!isModalOpen()) {
+    return
+  }
+
+  const playerElements = select.all('.roster .roster__member', parentElement)
+
+  if (playerElements.length === 0) {
+    return
+  }
+
+  /* Need to find a way to get the assoicated tournament or id on checkin
+  const tournamentId = getTournamentId()
+  const tournament = await getTournament(tournamentId)
+  const { game } = tournament */
+
+  const game = 'csgo'
+
+  playerElements.forEach(async playerElement => {
+    if (hasFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)) {
+      return
+    }
+
+    setFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)
+
+    const nicknameElement = select(
+      'strong[ng-bind="::member.nickname"]',
+      playerElement
+    )
+    const nickname = nicknameElement.textContent
+
+    const player = await getPlayer(nickname)
+
+    if (!player) {
+      return
+    }
+
+    const level = player.games[game].skillLevel || 0
+
+    const skillLevelElement = createSkillLevelElement({ level })
+
+    playerElement.prepend(
+      <div style={{ 'margin-right': '5px' }}>{skillLevelElement}</div>
+    )
+  })
+}

--- a/src/content/features/add-tournament-checkin-player-levels.js
+++ b/src/content/features/add-tournament-checkin-player-levels.js
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'dom-chef'
 import select from 'select-dom'
-import {  getPlayer } from '../libs/faceit'
+import { getPlayer } from '../libs/faceit'
 import { hasFeatureAttribute, setFeatureAttribute } from '../libs/dom-element'
 import { isModalOpen } from '../libs/utils'
 import createSkillLevelElement from '../components/skill-level'

--- a/src/content/features/add-tournament-checkin-player-stats.js
+++ b/src/content/features/add-tournament-checkin-player-stats.js
@@ -17,7 +17,7 @@ export default async parentElement => {
     return
   }
 
-  const playerElements = select.all('.roster .roster__member' , parentElement)
+  const playerElements = select.all('.roster .roster__member', parentElement)
 
   if (playerElements.length === 0) {
     return

--- a/src/content/features/add-tournament-checkin-player-stats.js
+++ b/src/content/features/add-tournament-checkin-player-stats.js
@@ -1,0 +1,66 @@
+/** @jsx h */
+import { h } from 'dom-chef'
+import select from 'select-dom'
+import { getPlayer, getPlayerStats } from '../libs/faceit'
+import {
+  hasFeatureAttribute,
+  setFeatureAttribute,
+  setStyle
+} from '../libs/dom-element'
+import { isModalOpen } from '../libs/utils'
+import createPlayerStatsElement from '../components/player-stats'
+
+const FEATURE_ATTRIBUTE = 'tournament-checkin-player-stats'
+
+export default async parentElement => {
+  if (!isModalOpen()) {
+    return
+  }
+
+  const playerElements = select.all('.roster .roster__member' , parentElement)
+
+  if (playerElements.length === 0) {
+    return
+  }
+
+  /* Need to find a way to get the assoicated tournament or id on checkin
+  const tournamentId = getTournamentId()
+  const tournament = await getTournament(tournamentId)
+  const { game } = tournament */
+
+  const game = 'csgo'
+
+  playerElements.forEach(async playerElement => {
+    if (hasFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)) {
+      return
+    }
+
+    setFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)
+
+    const nicknameElement = select(
+      'strong[ng-bind="::member.nickname"]',
+      playerElement
+    )
+    const nickname = nicknameElement.textContent
+
+    const player = await getPlayer(nickname)
+
+    if (!player) {
+      return
+    }
+
+    const { guid } = player
+    const stats = await getPlayerStats(guid, game)
+
+    if (!stats) {
+      return
+    }
+
+    const statsElement = createPlayerStatsElement(stats)
+
+    playerElement.after(<div style={{ width: '100%' }}>{statsElement}</div>)
+  })
+
+  const userList = select('.modal-dialog .roster')
+  setStyle(userList, 'margin-bottom: 25px')
+}

--- a/src/content/features/add-tournament-team-popup-player-elos.js
+++ b/src/content/features/add-tournament-team-popup-player-elos.js
@@ -1,0 +1,56 @@
+/** @jsx h */
+import { h } from 'dom-chef'
+import select from 'select-dom'
+import { getTournament, getPlayer } from '../libs/faceit'
+import { hasFeatureAttribute, setFeatureAttribute } from '../libs/dom-element'
+import { getTournamentId } from '../libs/tournament'
+import { isModalOpen } from '../libs/utils'
+import createEloElement from '../components/elo'
+
+const FEATURE_ATTRIBUTE = 'tournament-team-popup-player-elo'
+
+export default async parentElement => {
+  if (!isModalOpen()) {
+    return
+  }
+
+  const tournamentId = getTournamentId()
+  const tournament = await getTournament(tournamentId)
+  const { game } = tournament
+
+  const playerElements = select.all(
+    'li[ng-repeat="member in team.members | orderByTeamMemberRole"]',
+    parentElement
+  )
+
+  if (playerElements.length === 0) {
+    return
+  }
+
+  playerElements.forEach(async playerElement => {
+    if (hasFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)) {
+      return
+    }
+
+    setFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)
+
+    const userElement = select('div[class*="users-list__item"]', playerElement)
+    const nicknameElement = select(
+      'strong[ng-bind="member.nickname"]',
+      userElement
+    )
+    const nickname = nicknameElement.textContent
+
+    const player = await getPlayer(nickname)
+
+    if (!player) {
+      return
+    }
+
+    const elo = player.games[game].faceitElo || '–'
+
+    const eloElement = createEloElement({ elo, alignRight: true })
+
+    userElement.append(<div className="text-muted text-md">{eloElement}</div>)
+  })
+}

--- a/src/content/features/add-tournament-team-popup-player-stats.js
+++ b/src/content/features/add-tournament-team-popup-player-stats.js
@@ -1,0 +1,68 @@
+/** @jsx h */
+import { h } from 'dom-chef'
+import select from 'select-dom'
+import { getTournament, getPlayer, getPlayerStats } from '../libs/faceit'
+import {
+  hasFeatureAttribute,
+  setFeatureAttribute,
+  setStyle
+} from '../libs/dom-element'
+import { getTournamentId } from '../libs/tournament'
+import { isModalOpen } from '../libs/utils'
+import createPlayerStatsElement from '../components/player-stats'
+
+const FEATURE_ATTRIBUTE = 'tournament-team-popup-player-stats'
+
+export default async parentElement => {
+  if (!isModalOpen()) {
+    return
+  }
+
+  const tournamentId = getTournamentId()
+  const tournament = await getTournament(tournamentId)
+  const { game } = tournament
+
+  const playerElements = select.all(
+    'li[ng-repeat="member in team.members | orderByTeamMemberRole"]',
+    parentElement
+  )
+
+  if (playerElements.length === 0) {
+    return
+  }
+
+  playerElements.forEach(async playerElement => {
+    if (hasFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)) {
+      return
+    }
+
+    setFeatureAttribute(FEATURE_ATTRIBUTE, playerElement)
+
+    const userElement = select('div[class*="users-list__item"]', playerElement)
+    const nicknameElement = select(
+      'strong[ng-bind="member.nickname"]',
+      userElement
+    )
+    const nickname = nicknameElement.textContent
+
+    const player = await getPlayer(nickname)
+
+    if (!player) {
+      return
+    }
+
+    const { guid } = player
+    const stats = await getPlayerStats(guid, game)
+
+    if (!stats) {
+      return
+    }
+
+    const statsElement = createPlayerStatsElement(stats)
+
+    playerElement.append(<div style={{ width: '100%' }}>{statsElement}</div>)
+  })
+
+  const userList = select('.modal-dialog .users-list')
+  setStyle(userList, 'margin-bottom: 25px')
+}

--- a/src/content/features/add-tournament-team-popup-team-elos.js
+++ b/src/content/features/add-tournament-team-popup-team-elos.js
@@ -1,0 +1,66 @@
+/** @jsx h */
+import { h } from 'dom-chef'
+import select from 'select-dom'
+
+import { getTournament, getPlayer } from '../libs/faceit'
+import { hasFeatureAttribute, setFeatureAttribute } from '../libs/dom-element'
+import { getTournamentId } from '../libs/tournament'
+import { isModalOpen } from '../libs/utils'
+
+const FEATURE_ATTRIBUTE = 'tournament-team-popup-team-elo'
+
+export default async parentElement => {
+  if (!isModalOpen()) {
+    return
+  }
+
+  const userList = select('.modal-dialog .users-list', parentElement)
+
+  if (hasFeatureAttribute(FEATURE_ATTRIBUTE, userList)) {
+    return
+  }
+
+  const playerElements = select.all(
+    'li[ng-repeat="member in team.members | orderByTeamMemberRole"]'
+  )
+
+  if (playerElements.length === 0) {
+    return
+  }
+
+  setFeatureAttribute(FEATURE_ATTRIBUTE, userList)
+
+  const tournamentId = getTournamentId()
+  const tournament = await getTournament(tournamentId)
+  const { game } = tournament
+
+  const players = await Promise.all(
+    playerElements.map(playerElement => {
+      const nicknameElement = select(
+        'strong[ng-bind="member.nickname"]',
+        playerElement
+      )
+      const nickname = nicknameElement.textContent
+      return getPlayer(nickname)
+    })
+  )
+
+  const totalElo = players
+    .map(player => {
+      return player.games[game].faceitElo
+    })
+    .reduce((accumulator, currentValue) => accumulator + currentValue)
+
+  const averageElo = Math.floor(totalElo / players.length)
+
+  const eloElement = (
+    <div
+      className="text-muted text-md"
+      style={{ 'margin-bottom': 6, 'text-align': 'center' }}
+    >
+      Avg. Elo: {averageElo}
+    </div>
+  )
+
+  userList.before(eloElement)
+}

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -33,6 +33,13 @@ import showSidebarMatchmakingQueuing from './features/show-sidebar-matchmaking-q
 import addSidebarHideButton from './features/add-sidebar-hide-button'
 import addPlayerProfileDownloadDemo from './features/add-player-profile-download-demo'
 import addPlayerProfileExtendedStats from './features/add-player-profile-extended-stats'
+import addTournamentCheckinPlayerFlags from './features/add-tournament-checkin-player-flags'
+import addTournamentCheckinPlayerElos from './features/add-tournament-checkin-player-elos'
+import addTournamentCheckinPlayerLevels from './features/add-tournament-checkin-player-levels'
+import addTournamentCheckinPlayerStats from './features/add-tournament-checkin-player-stats'
+import addTournamentTeamPopupPlayerElos from './features/add-tournament-team-popup-player-elos'
+import addTournamentTeamPopupPlayerStats from './features/add-tournament-team-popup-player-stats'
+import addTournamentTeamPopupTeamElos from './features/add-tournament-team-popup-team-elos'
 import clickModalClose from './features/click-modal-close'
 import showSidebarHubQueuing from './features/show-sidebar-hub-queuing'
 import isUserBanned from './bans/is-user-banned'
@@ -72,6 +79,10 @@ function observeMainContent(element) {
       addMatchRoomPickPlayerStats(element)
       addMatchRoomPickPlayerElos(element)
       addMatchRoomPickPlayerFlags(element)
+    } else if (pages.isTournamentOverview()) {
+      addTournamentTeamPopupPlayerElos(element)
+      addTournamentTeamPopupTeamElos(element)
+      addTournamentTeamPopupPlayerStats(element)
     } else if (pages.isPlayerProfileStats()) {
       runFeatureIf(
         'playerProfileLevelProgress',
@@ -81,6 +92,12 @@ function observeMainContent(element) {
       addProfileMatchesEloPoints(element)
       addPlayerProfileDownloadDemo(element)
       addPlayerProfileExtendedStats(element)
+    }
+    if (pages.hasTournamentCheckin()) {
+      addTournamentCheckinPlayerFlags(element)
+      addTournamentCheckinPlayerElos(element)
+      addTournamentCheckinPlayerLevels(element)
+      addTournamentCheckinPlayerStats(element)
     }
   }
 
@@ -145,7 +162,7 @@ function observeBody() {
     addSidebarHideButton()
 
     if (!mainContentElement) {
-      mainContentElement = select('#main-content')
+      mainContentElement = select('body')
       if (mainContentElement) {
         observeMainContent(mainContentElement)
       }

--- a/src/content/libs/faceit.js
+++ b/src/content/libs/faceit.js
@@ -112,6 +112,9 @@ export const getPlayerDivision = async (userId, game, region) => {
   }
 }
 
+export const getTournament = tournamentId =>
+  fetchApiMemoized(`/core/v1/tournaments/${tournamentId}`)
+
 export const getQuickMatch = matchId =>
   fetchApiMemoized(`/core/v1/matches/${matchId}?withStats=true`)
 

--- a/src/content/libs/pages.js
+++ b/src/content/libs/pages.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+import select from 'select-dom'
 import { getCurrentPath } from './location'
 
 export const isRoomOverview = path =>
@@ -6,3 +7,9 @@ export const isRoomOverview = path =>
 
 export const isPlayerProfileStats = path =>
   /players\/.+\/stats\//.test(path || getCurrentPath())
+
+export const isTournamentOverview = () => path =>
+  /tournament\/.+-.+-.+-.+$/.test(path || getCurrentPath())
+
+export const hasTournamentCheckin = () =>
+  select('.modal-dialog__header__title[translate-once="TEAM-FOUND"]') !== null

--- a/src/content/libs/tournament.js
+++ b/src/content/libs/tournament.js
@@ -1,0 +1,13 @@
+import select from 'select-dom'
+import { getCurrentPath } from './location'
+
+export const getTournamentId = path => {
+  const match = /tournament\/([0-9a-z]+-[0-9a-z]+-[0-9a-z]+-[0-9a-z]+-[0-9a-z]+(?:-[0-9a-z]+)?)/.exec(
+    path || getCurrentPath()
+  )
+  return match && match[1]
+}
+
+export const getRosterMembers = parentElement => {
+  return select.all('.roster .roster__member', parentElement)
+}

--- a/src/content/libs/utils.js
+++ b/src/content/libs/utils.js
@@ -31,5 +31,7 @@ export const notifyIf = async (option, message) => {
   }
 }
 
+export const isModalOpen = () => select.exists('.modal-dialog')
+
 export const isLoggedIn = () =>
   !select.exists('.main-header__right__logged-out')


### PR DESCRIPTION
Added;

- Flags, elo and recent stats for players in tournament roster on check-in popup (useful when solo-q)
- Elo and recent stats to players on team details popup (on clicking team name from tournament overview)