### PR TITLE
Fix ELO changes in match history page and some small fixes

### DIFF
--- a/src/content/features/add-profile-matches-elo-points.js
+++ b/src/content/features/add-profile-matches-elo-points.js
@@ -18,6 +18,7 @@ import { calculateRatingChange } from '../helpers/elo'
 import { getIsFreeMember } from '../helpers/membership'
 
 const FEATURE_ATTRIBUTE = 'elo-points'
+const MATCHES_PER_PAGE = 30 // FACEIT defined. Check the website to make sure this is up to date.
 let nextPage = 0
 
 export default async parentElement => {
@@ -45,20 +46,26 @@ export default async parentElement => {
     return
   }
 
-  if (matchElements.length > nextPage * 30) {
+  if (matchElements.length > nextPage * MATCHES_PER_PAGE) {
     const currentPage = nextPage
     nextPage += 1
 
     // Page generated more matches for us to fetch.
-    const matches = await getPlayerMatches(player.guid, player.flag, 30, currentPage)
+    const matches = await getPlayerMatches(
+      player.guid,
+      player.flag,
+      MATCHES_PER_PAGE,
+      currentPage
+    )
 
     const matchesById = await mapMatchesWithElo(matches, game)
-    if (!matchesById) { // No elo enabled matches found
+    if (!matchesById) {
+      // No elo enabled matches found
       return
     }
 
     matches.forEach(async (match, index) => {
-      const matchHistoryTableRow = currentPage * 30 + index
+      const matchHistoryTableRow = currentPage * MATCHES_PER_PAGE + index
       const matchElement = matchElements[matchHistoryTableRow]
       const matchId = match.matchId
       if (hasFeatureAttribute(FEATURE_ATTRIBUTE, matchElement)) {
@@ -105,7 +112,7 @@ export default async parentElement => {
         const gainedElo = eloDiff > 0
         resultElement.textContent = `${resultElement.textContent} (${
           gainedElo ? '+' : ''
-          }${eloDiff})`
+        }${eloDiff})`
       }
 
       if (selfHasFreeMembership || !eloAfter) {

--- a/src/content/features/add-profile-matches-elo-points.js
+++ b/src/content/features/add-profile-matches-elo-points.js
@@ -46,6 +46,13 @@ export default async parentElement => {
     return
   }
 
+  // Check if the first row has 'elo-points' applied.
+  // If it doesn't, nextPage should be 0. This is required
+  // because a user may navigate away and back to the stats page.
+  if (!hasFeatureAttribute(FEATURE_ATTRIBUTE, matchElements[0])) {
+    nextPage = 0
+  }
+
   if (matchElements.length > nextPage * MATCHES_PER_PAGE) {
     const currentPage = nextPage
     nextPage += 1
@@ -124,7 +131,6 @@ export default async parentElement => {
           New Elo: {eloAfter}
         </div>
       )
-      console.log(resultElement)
       resultElement.append(newEloElement)
     })
   }

--- a/src/content/features/add-sidebar-matches-elo.js
+++ b/src/content/features/add-sidebar-matches-elo.js
@@ -30,7 +30,7 @@ export default async () => {
   const isFreeMember = getIsFreeMember(self)
 
   let matches = await getPlayerMatches(self.guid, game)
-  matches = mapMatchesWithElo(matches, game)
+  matches = await mapMatchesWithElo(matches, game)
 
   if (!matches) {
     return

--- a/src/content/helpers/faceit-api.js
+++ b/src/content/helpers/faceit-api.js
@@ -63,9 +63,9 @@ export const getUser = userId => fetchApiMemoized(`/core/v1/users/${userId}`)
 export const getPlayer = nickname =>
   fetchApiMemoized(`/core/v1/nicknames/${nickname}`)
 
-export const getPlayerMatches = (userId, game, size = 21) =>
+export const getPlayerMatches = (userId, game, size = 21, page = 0) =>
   fetchApiMemoized(
-    `/stats/v1/stats/time/users/${userId}/games/${game}?size=${size}`
+    `/stats/v1/stats/time/users/${userId}/games/${game}?page=${page}&size=${size}`
   )
 
 export const getPlayerStats = async (userId, game, size = 20) => {
@@ -135,3 +135,6 @@ export const getPlayerHistory = async (userId, page = 0) => {
     `/match-history/v5/players/${userId}/history/?from=${from}&to=${to}&page=${page}&size=${size}&offset=${offset}`
   )
 }
+
+export const getMatchmakingQueue = queueId =>
+  fetchApiMemoized(`/queue/v1/queue/matchmaking/${queueId}`)

--- a/src/content/helpers/matches.js
+++ b/src/content/helpers/matches.js
@@ -1,15 +1,36 @@
 /* eslint-disable import/prefer-default-export */
 import { normalizeElo } from './elo'
+import { getMatchmakingQueue } from './faceit-api';
 
-export function mapMatchesWithElo(matches, game) {
-  const matchesByGame = matches.filter(match => match.game === game)
+async function asyncForEach(array, callback) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
+}
+
+export async function mapMatchesWithElo(matches, game) {
+  let eloEnabled = {}
+
+  await asyncForEach(matches, async (match) => {
+    if (match.competitionId) { // Note: Old matches won't have competitionId
+      let queue = await getMatchmakingQueue(match.competitionId);
+      eloEnabled[match.competitionId] = queue.length > 0 ? queue[0].calculateElo : false;
+    }
+  })
+
+  const matchesByGame = matches.filter(match => {
+      //match.game === game
+      //console.log(eloEnabled[match.competitionId] + ' ' + match.competitionId)
+      return match.game === game && eloEnabled[match.competitionId]
+    }
+  )
 
   if (matchesByGame.length === 0) {
     return null
   }
 
   return matchesByGame.reduce((acc, { matchId, elo, ...match }, i) => {
-    if (matches.length === i + 1) {
+    if (matchesByGame.length === i + 1) {
       return acc
     }
 

--- a/src/content/helpers/matches.js
+++ b/src/content/helpers/matches.js
@@ -1,29 +1,24 @@
 /* eslint-disable import/prefer-default-export */
 import { normalizeElo } from './elo'
-import { getMatchmakingQueue } from './faceit-api';
-
-async function asyncForEach(array, callback) {
-  for (let index = 0; index < array.length; index++) {
-    await callback(array[index], index, array);
-  }
-}
+import { getMatchmakingQueue } from './faceit-api'
 
 export async function mapMatchesWithElo(matches, game) {
-  let eloEnabled = {}
+  const eloEnabled = {}
 
-  await asyncForEach(matches, async (match) => {
-    if (match.competitionId) { // Note: Old matches won't have competitionId
-      let queue = await getMatchmakingQueue(match.competitionId);
-      eloEnabled[match.competitionId] = queue.length > 0 ? queue[0].calculateElo : false;
+  const matchPromises = matches.map(async match => {
+    const competitionId = match.competitionId
+    // Note: Old matches won't have competitionId
+    if (competitionId) {
+      const queue = await getMatchmakingQueue(competitionId)
+      eloEnabled[competitionId] = queue.length > 0 && queue[0].calculateElo
     }
   })
 
+  await Promise.all(matchPromises)
+
   const matchesByGame = matches.filter(match => {
-      //match.game === game
-      //console.log(eloEnabled[match.competitionId] + ' ' + match.competitionId)
-      return match.game === game && eloEnabled[match.competitionId]
-    }
-  )
+    return match.game === game && eloEnabled[match.competitionId]
+  })
 
   if (matchesByGame.length === 0) {
     return null

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -40,9 +40,8 @@ import addMatchRoomEloSelfResult from './features/add-match-room-elo-self-result
 import applyMatchRoomFocusMode from './features/apply-match-room-focus-mode'
 
 function observeBody() {
-  const observer = new MutationObserver(() => {
+  const observer = new MutationObserver((mutations) => {
     const modalElement = select('.modal-dialog')
-
     if (modalElement) {
       if (modals.isInviteToParty(modalElement)) {
         runFeatureIf(
@@ -154,8 +153,13 @@ function observeBody() {
           addPlayerProfileLevelProgress,
           mainContentElement
         )
+        const statsTable = select('div.js-match-history-stats > table > tbody')
+        mutations.forEach((mutation) => {
+          if (mutation.type === "childList" && mutation.target === statsTable) {
+            addProfileMatchesEloPoints(mainContentElement)
+          }
+        })
         addPlayerProfileDownloadDemo(mainContentElement)
-        addProfileMatchesEloPoints(mainContentElement)
         addPlayerProfileExtendedStats(mainContentElement)
       }
     }


### PR DESCRIPTION
This PR fixes an issue where a player's match history does not show ELO changes as the user paginates/scrolls down, and another issue where the ELO changes are reflected on the wrong matches (see picture). 

![bug](https://i.imgur.com/Qvmk4Ye.png)

Now it supports the ELO change feature for all matches possible. It also takes into account matches that aren't enabled to affect ELO, so it disregards them during calculation.

You will see that I decided to not use getMatchHistory all together. It didn't seem like it was working (seems to take a while to get up to date information), and I also felt like it was unnecessary. getPlayerMatches, which was already being used, is enough to get by.

Other small changes include:
- selfHasFreeMembership in add-profile-matches-elo-points.js now uses the getIsFreeMember helper
- getPlayerMatches in faceit-api.js now supports the 'page' query
- Added getMatchmakingQueue endpoint to faceit-api.js, which returns information about a matchmaking (ELO enabled) queue
- Fixes mapMatchesById AND has that function filter out non-ELO enabled matches (such as those played in Hubs), so that ELO calculations can be done safely.
- Add "mutations" in the main DOM observer so that addProfileMatchesEloPoints will only be called on stat table updates.
