### PR TITLE
Fixed line-height issue in elo-estimation

### DIFF
--- a/src/content/features/add-match-room-elo-estimation.js
+++ b/src/content/features/add-match-room-elo-estimation.js
@@ -149,6 +149,7 @@ export default async parent => {
       </div>
     )
 
+    factionNicknameElement.style.lineHeight = 'normal'
     factionNicknameElement.append(eloElement)
 
     const factionIndex = i + 1


### PR DESCRIPTION
Fixed line-height issue in match room elo estimation.

Currently: 
![current](https://user-images.githubusercontent.com/42501026/79054780-86dbc880-7c50-11ea-8139-fffca426ab31.png)

Updated:
![updated](https://user-images.githubusercontent.com/42501026/79054788-92c78a80-7c50-11ea-963f-165e105aacfe.png)
