### PR TITLE
Update line height on elo estimation to stop overlap.

### DIFF
--- a/src/content/features/add-match-room-elo-estimation.js
+++ b/src/content/features/add-match-room-elo-estimation.js
@@ -149,7 +149,7 @@ export default async parent => {
       </div>
     )
 
-    factionNicknameElement.style.lineHeight = 'normal'
+    factionNicknameElement.style.lineHeight = '1'
     factionNicknameElement.append(eloElement)
 
     const factionIndex = i + 1


### PR DESCRIPTION
Fixes the below by just changing the line height on the `factionNicknameElement`.

![Before](https://i.gyazo.com/f63142bdc314ed68f36ae1b7f8afb0ca.png)

![After](https://i.gyazo.com/18dd4bc7f36542c47e37d87f5e465d8d.png)