### PR TITLE
fix: Lobby social links edge case with twitch connection

### DIFF
--- a/src/content/features/add-match-room-player-links.js
+++ b/src/content/features/add-match-room-player-links.js
@@ -63,7 +63,11 @@ export default async parent => {
 
       const user = await getUser(userId)
 
-      if (!user || !user.socials || Object.keys(user.socials).length === 0) {
+      if (
+        !user ||
+        ((!user.socials || Object.keys(user.socials).length === 0) &&
+          !(user.streaming || user.streaming.twitchId))
+      ) {
         return
       }
 

--- a/src/content/features/add-match-room-player-links.js
+++ b/src/content/features/add-match-room-player-links.js
@@ -66,7 +66,7 @@ export default async parent => {
       if (
         !user ||
         ((!user.socials || Object.keys(user.socials).length === 0) &&
-          !(user.streaming || user.streaming.twitchId))
+          (!user.streaming || !user.streaming.twitchId))
       ) {
         return
       }


### PR DESCRIPTION
If user only has twitch connection set, it wouldn't show up in lobby social links. This fixes it.