### PR TITLE
fix: Enhancer badge to work with new parasite UI

### DIFF
--- a/src/content/components/player-badge.js
+++ b/src/content/components/player-badge.js
@@ -25,11 +25,19 @@ export default ({ level = 0, role, bgColor, textColor, onClick }) => {
 
   return (
     <span
-      className="label"
       style={{
         background: bgColor || vipLevels[level].bgColor,
         color: textColor || vipLevels[level].textColor,
-        cursor: 'help'
+        cursor: 'help',
+        padding: '.2em .5em .3em',
+        display: 'inline',
+        fontSize: '75%',
+        fontWeight: '700',
+        lineHeight: 1,
+        textAlign: 'center',
+        whiteSpace: 'nowrap',
+        verticalAlign: 'baseline',
+        borderRadius: '.25em'
       }}
       title={description}
       onClick={onClick}

--- a/src/content/components/player-badge.js
+++ b/src/content/components/player-badge.js
@@ -32,7 +32,7 @@ export default ({ level = 0, role, bgColor, textColor, onClick }) => {
         padding: '.2em .5em .3em',
         display: 'inline',
         fontSize: '75%',
-        fontWeight: '700',
+        fontWeight: 700,
         lineHeight: 1,
         textAlign: 'center',
         whiteSpace: 'nowrap',

--- a/src/content/features/add-player-profile-badge.js
+++ b/src/content/features/add-player-profile-badge.js
@@ -17,19 +17,19 @@ const FEATURE_ATTRIBUTE = 'profile-badge'
 export default async parentElement => {
   const playerBanner = select('parasite-player-banner', parentElement)
 
-  if (playerBanner === null || playerBanner.shadowRoot === null) {
+  if (!playerBanner || !playerBanner.shadowRoot) {
     return
   }
 
   const playerNameElement = select('h5[size="5"]', playerBanner.shadowRoot)
 
-  if (playerNameElement === null || playerNameElement.parentElement === null) {
+  if (!playerNameElement || !playerNameElement.parentElement) {
     return
   }
 
   const wrapper = playerNameElement.parentElement.parentElement
 
-  if (wrapper === null) {
+  if (!wrapper) {
     return
   }
 
@@ -52,7 +52,17 @@ export default async parentElement => {
   )
 
   const badgeWrapper = (
-    <div style={{ marginBottom: '.5em' }}>{featuredPlayerBadgeElement}</div>
+    <div
+      style={{
+        marginBottom: '.5em',
+        marginTop:
+          wrapper.firstElementChild === playerNameElement.parentElement
+            ? undefined
+            : '.5em'
+      }}
+    >
+      {featuredPlayerBadgeElement}
+    </div>
   )
 
   wrapper.insertBefore(badgeWrapper, playerNameElement.parentElement)

--- a/src/content/features/add-player-profile-badge.js
+++ b/src/content/features/add-player-profile-badge.js
@@ -15,20 +15,29 @@ import { getPlayer } from '../helpers/faceit-api'
 const FEATURE_ATTRIBUTE = 'profile-badge'
 
 export default async parentElement => {
-  const badgeElement = select(
-    'div.page-title__content > div.page-title__content__title',
-    parentElement
-  )
+  const playerBanner = select('parasite-player-banner', parentElement)
 
-  if (badgeElement === null) {
+  if (playerBanner === null || playerBanner.shadowRoot === null) {
     return
   }
 
-  if (hasFeatureAttribute(FEATURE_ATTRIBUTE, badgeElement)) {
+  const playerNameElement = select('h5[size="5"]', playerBanner.shadowRoot)
+
+  if (playerNameElement === null || playerNameElement.parentElement === null) {
     return
   }
 
-  setFeatureAttribute(FEATURE_ATTRIBUTE, badgeElement)
+  const wrapper = playerNameElement.parentElement.parentElement
+
+  if (wrapper === null) {
+    return
+  }
+
+  if (hasFeatureAttribute(FEATURE_ATTRIBUTE, wrapper)) {
+    return
+  }
+
+  setFeatureAttribute(FEATURE_ATTRIBUTE, wrapper)
 
   const nickname = getPlayerProfileNickname()
   const { guid } = await getPlayer(nickname)
@@ -42,7 +51,9 @@ export default async parentElement => {
     playerBadge
   )
 
-  const badgeWrapper = <div className="mb-sm">{featuredPlayerBadgeElement}</div>
+  const badgeWrapper = (
+    <div style={{ marginBottom: '.5em' }}>{featuredPlayerBadgeElement}</div>
+  )
 
-  badgeElement.insertBefore(badgeWrapper, badgeElement.firstChild)
+  wrapper.insertBefore(badgeWrapper, playerNameElement.parentElement)
 }


### PR DESCRIPTION
Fixed selectors to work with new parasite profile UI. Not sure if this new "parasite" UI is currently shipped to every user or just a select few (Comment tags in HTML warning its experimental).

Since new UI doesn't seem to use bootstrap classes in readable way, label class was changed to work standalone.

Picture of label
![Picture of label](https://user-images.githubusercontent.com/42501026/103683060-639d3a00-4f92-11eb-9b94-902c6ca20598.png)
