### PR TITLE
Feature: match progress bar style with FBI style

### DIFF
--- a/src/content/features/add-header-level-progress.js
+++ b/src/content/features/add-header-level-progress.js
@@ -43,10 +43,9 @@ export default async () => {
     const { skillLevel, faceitElo = 1000 } = games[game]
     const [levelMinElo, levelMaxElo] = LEVELS[skillLevel]
 
-    const toProgressWidth = levelMaxElo
-      ? `${100 -
-          ((faceitElo - levelMinElo) / (levelMaxElo - levelMinElo)) * 100}%`
-      : 0
+    const progressWidth = levelMaxElo
+      ? `${((faceitElo - levelMinElo) / (levelMaxElo - levelMinElo)) * 100}%`
+      : '100%'
 
     const levelBelow = LEVELS[skillLevel - 1]
     const levelAbove = LEVELS[skillLevel + 1]
@@ -123,16 +122,15 @@ export default async () => {
                 margin: '1px 0',
                 height: 2,
                 width: 110,
-                background:
-                  'linear-gradient(90deg,#c00000,red,#fd8003,#ffc000,#ff0,#92d050,#52ba28,#47a123,#00b050)'
+                background: '#4b4e4e'
               }}
             >
               <div
                 style={{
                   height: '100%',
-                  width: toProgressWidth,
-                  background: '#4b4e4e',
-                  float: 'right'
+                  width: progressWidth,
+                  background:
+                    'linear-gradient(270deg,#ff5500 0%,rgba(255,85,0,0.08) 100%)'
                 }}
               />
             </div>

--- a/src/content/features/add-header-level-progress.js
+++ b/src/content/features/add-header-level-progress.js
@@ -43,9 +43,10 @@ export default async () => {
     const { skillLevel, faceitElo = 1000 } = games[game]
     const [levelMinElo, levelMaxElo] = LEVELS[skillLevel]
 
-    const progressWidth = levelMaxElo
-      ? `${((faceitElo - levelMinElo) / (levelMaxElo - levelMinElo)) * 100}%`
-      : '100%'
+    const toProgressWidth = levelMaxElo
+      ? `${100 -
+          ((faceitElo - levelMinElo) / (levelMaxElo - levelMinElo)) * 100}%`
+      : 0
 
     const levelBelow = LEVELS[skillLevel - 1]
     const levelAbove = LEVELS[skillLevel + 1]
@@ -122,14 +123,16 @@ export default async () => {
                 margin: '1px 0',
                 height: 2,
                 width: 110,
-                background: '#4b4e4e'
+                background:
+                  'linear-gradient(90deg,#c00000,red,#fd8003,#ffc000,#ff0,#92d050,#52ba28,#47a123,#00b050)'
               }}
             >
               <div
                 style={{
                   height: '100%',
-                  width: progressWidth,
-                  background: '#f50'
+                  width: toProgressWidth,
+                  background: '#4b4e4e',
+                  float: 'right'
                 }}
               />
             </div>


### PR DESCRIPTION
Hey,

i've updated the style of the progress bar in the header-level-progress to match the style of the Faceit Behavior Index.

Before : 
<img width="159" alt="Screenshot 2021-12-02 at 10 46 40" src="https://user-images.githubusercontent.com/23510328/144401739-e49d1df1-5f1d-4fab-bf0b-09ff87822516.png">
After : 
<img width="159" alt="Screenshot 2021-12-02 at 10 51 46" src="https://user-images.githubusercontent.com/23510328/144401745-41d8198f-7516-41b6-96e0-a31dd825eee8.png">


